### PR TITLE
Set supported Crystal version in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,6 @@ version: 0.1.1
 authors:
   - Mikael Karlsson <i8myshoes@gmail.com>
 
+crystal: ">= 0.31, < 2.0"
+
 license: MIT


### PR DESCRIPTION
I am updating [CrOTP](https://github.com/philnash/crotp) to say that it supports Crystal 1.0.0, but I now have a Crystal version clash when installing the dependencies. The issue seems to come from base32 not having a crystal version defined in the `shard.yml` which is implying support for Crystal < 1.0.0 (see [the error in the jobs here](https://github.com/philnash/crotp/actions/runs/938428927)). 

This PR sets the support to ">= 0.31, < 2.0" which I believe satisfies the shard's support.